### PR TITLE
fix: chalk 5.0.0 breaks build because esm format

### DIFF
--- a/.changeset/fifty-days-wonder.md
+++ b/.changeset/fifty-days-wonder.md
@@ -1,0 +1,5 @@
+---
+'@websublime/vtx-cli': patch
+---
+
+Chalk dependency downgrade

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@websublime/vtx-common": "^0.0.3",
     "cac": "^6.7.12",
-    "chalk": "^5.0.0",
+    "chalk": "^4.1.2",
     "fs-extra": "^10.0.0",
     "prompts": "^2.4.2",
     "vite": "2.6.14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -446,10 +446,13 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.0.tgz#bd96c6bb8e02b96e08c0c3ee2a9d90e050c7b832"
-  integrity sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==
+chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 chardet@^0.7.0:
   version "0.7.0"


### PR DESCRIPTION
Chal dependency downgrade